### PR TITLE
IPE component bugfix

### DIFF
--- a/java/org/opensha/sha/imr/AttenuationRelationship.java
+++ b/java/org/opensha/sha/imr/AttenuationRelationship.java
@@ -18,6 +18,8 @@
 
 package org.opensha.sha.imr;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -971,11 +973,15 @@ public abstract class AttenuationRelationship extends
             }
             else
             {
-                String msg = "The chosen component " + component + " is not supported by "
-                        + getClass().getCanonicalName() + "The supported components are the following:\n"
-                        + parameter.getConstraint() + "\nCheck your input file!\n" + "Execution stopped.";
+                StringWriter writer = new StringWriter();
+                PrintWriter printer = new PrintWriter(writer);
+                
+                printer.print("The chosen component " + component + " ");
+                printer.println("is not supported by " + getClass().getCanonicalName());
+                printer.println("The supported components are the following:");
+                printer.println(parameter.getConstraint());
 
-                throw new IllegalArgumentException(msg);
+                throw new IllegalArgumentException(writer.toString());
             }
         }
     }

--- a/java/org/opensha/sha/imr/AttenuationRelationship.java
+++ b/java/org/opensha/sha/imr/AttenuationRelationship.java
@@ -257,14 +257,11 @@ import org.opensha.sha.util.TectonicRegionType;
  * @version 1.0
  */
 
-/* 
- * 
- *
- */
-
 public abstract class AttenuationRelationship extends
         IntensityMeasureRelationship implements
         ScalarIntensityMeasureRelationshipAPI {
+
+    private static final long serialVersionUID = -5230687816643155822L;
 
     /**
      * Classname constant used for debugging statements
@@ -951,6 +948,36 @@ public abstract class AttenuationRelationship extends
      */
     public boolean isTectonicRegionSupported(TectonicRegionType tectRegion) {
         return isTectonicRegionSupported(tectRegion.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    /**
+     * Sets the component identified by the given name,
+     * if the IMT (Intensity Measure Type) allows it.
+     * 
+     * @param component the component name
+     * @param intensityMeasureType the intensity measure type
+     * @throws IllegalArgumentException when the given component is not available for this relationship
+     */
+    public void setComponentParameter(String component, String intensityMeasureType)
+    {
+        if (!intensityMeasureType.equalsIgnoreCase("MMI"))
+        {
+            ParameterAPI<Object> parameter = getParameter(ComponentParam.NAME);
+            
+            if (parameter.isAllowed(component))
+            {
+                parameter.setValue(component);
+            }
+            else
+            {
+                String msg = "The chosen component " + component + " is not supported by "
+                        + getClass().getCanonicalName() + "The supported components are the following:\n"
+                        + parameter.getConstraint() + "\nCheck your input file!\n" + "Execution stopped.";
+
+                throw new IllegalArgumentException(msg);
+            }
+        }
     }
 
 }

--- a/java_tests/org/opensha/sha/imr/AttenuationRelationshipTest.java
+++ b/java_tests/org/opensha/sha/imr/AttenuationRelationshipTest.java
@@ -1,0 +1,54 @@
+package org.opensha.sha.imr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensha.commons.param.event.ParameterChangeWarningEvent;
+import org.opensha.commons.param.event.ParameterChangeWarningListener;
+import org.opensha.sha.imr.attenRelImpl.BA_2008_AttenRel;
+import org.opensha.sha.imr.param.OtherParams.ComponentParam;
+
+public class AttenuationRelationshipTest
+{
+
+    private AttenuationRelationship ar;
+
+    @Before
+    public void setUp()
+    {
+        ar = new BA_2008_AttenRel(new ParameterChangeWarningListener()
+        {
+
+            @Override
+            public void parameterChangeWarning(ParameterChangeWarningEvent event)
+            {
+                // TODO Auto-generated method stub
+            }
+        });
+    }
+
+    @Test
+    public void whenMeasureTypeIsMMINoComponentIsSet()
+    {
+        ar.setComponentParameter("COMPONENT_NAME", "MMI");
+        assertNull(null, ar.getParameter(ComponentParam.NAME).getValue());
+    }
+
+    @Test
+    public void whenMeasureTypeIsNotMMITheComponentIsSet()
+    {
+        // Average Horizontal (GMRotI50) is a supported parameter name
+        ar.setComponentParameter("Average Horizontal (GMRotI50)", "AAA");
+        assertEquals("Average Horizontal (GMRotI50)", ar.getParameter(ComponentParam.NAME).getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenTheComponentIsNotSupportedAnExceptionIsRaised()
+    {
+        ar.setComponentParameter("NOT_SUPPORTED", "AAA");
+        assertEquals("NOT_SUPPORTED", ar.getParameter(ComponentParam.NAME).getValue());
+    }
+
+}

--- a/java_tests/org/opensha/sha/imr/attenRelImpl/test/AttenRelTestsSuite.java
+++ b/java_tests/org/opensha/sha/imr/attenRelImpl/test/AttenRelTestsSuite.java
@@ -20,16 +20,16 @@ package org.opensha.sha.imr.attenRelImpl.test;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.opensha.sha.imr.AttenuationRelationshipTest;
 import org.opensha.sha.imr.attenRelImpl.BW_1997_AttenRelTest;
-
-;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ Spudich_1999_test.class, Abrahamson_2000_test.class,
         Abrahamson_Silva_1997_test.class, AW_2010_test.class, BJF_1997_test.class,
         BW_1997_AttenRelTest.class, CB_2003_test.class, Campbell_1997_test.class, 
         Field_2000_test.class, AS_2008_test.class, BA_2008_test.class, 
-        CB_2008_test.class, CY_2008_test.class, NGA08_Site_EqkRup_Tests.class, CL_2002_test.class })
+        CB_2008_test.class, CY_2008_test.class, NGA08_Site_EqkRup_Tests.class, CL_2002_test.class,
+        AttenuationRelationshipTest.class })
 /**
  * <p>Title: </p>
  * <p>Description: </p>


### PR DESCRIPTION
This pull request is the first step to fix [this issue](https://github.com/gem/openquake/issues/216). The second, and final, step is to update the _opensha-lite.jar_ in OQ and call the method _AttenuationRelationship.setComponentParameter_ from _GmpeLogicTreeData.setGmpeParams_.
