### PR TITLE
Fixed Site equality test and hashing

### DIFF
--- a/java/org/opensha/commons/data/Site.java
+++ b/java/org/opensha/commons/data/Site.java
@@ -163,7 +163,9 @@ public class Site extends ParameterList implements NamedObjectAPI,
      */
     public boolean equalsSite(Site site) {
 
-        if (!name.equals(site.name))
+        if ((name == null || site.name == null) && name != site.name)
+            return false;
+        if (name != null && !name.equals(site.name))
             return false;
         if (!location.equals(site.location))
             return false;

--- a/java/org/opensha/commons/data/Site.java
+++ b/java/org/opensha/commons/data/Site.java
@@ -190,6 +190,14 @@ public class Site extends ParameterList implements NamedObjectAPI,
     }
 
     /**
+     * This is weaker than necessary (does not take properties into account)
+     * but at least is correct.
+     */
+    public int hashCode() {
+        return location.hashCode() ^ (name != null ? name.hashCode() : 0);
+    }
+
+    /**
      * Returns a copy of this list, therefore any changes to the copy cannot
      * affect this original list. The name, Location and each parameter is
      * cloned.

--- a/java/org/opensha/commons/data/Site.java
+++ b/java/org/opensha/commons/data/Site.java
@@ -172,38 +172,7 @@ public class Site extends ParameterList implements NamedObjectAPI,
         if (this.size() != site.size())
             return false;
 
-        // Check each individual Parameter
-        ListIterator it = this.getParametersIterator();
-        while (it.hasNext()) {
-
-            // This list's parameter
-            ParameterAPI param1 = (ParameterAPI) it.next();
-
-            // List may not contain parameter with this list's parameter name
-            if (!site.containsParameter(param1.getName()))
-                return false;
-
-            // Found two parameters with same name, check equals, actually
-            // redundent,
-            // because that is what equals does
-            ParameterAPI param2 =
-                    (ParameterAPI) site.getParameter(param1.getName());
-            if (!param1.equals(param2))
-                return false;
-
-            // Now try compare to to see if value the same, can fail if two
-            // values
-            // are different, or if the value object types are different
-            try {
-                if (param1.compareTo(param2) != 0)
-                    return false;
-            } catch (ClassCastException ee) {
-                return false;
-            }
-
-        }
-
-        return true;
+        return equalsParameterList(site);
     }
 
     /**

--- a/java/org/opensha/commons/param/ParameterList.java
+++ b/java/org/opensha/commons/param/ParameterList.java
@@ -410,12 +410,19 @@ public class ParameterList implements Serializable, Iterable<ParameterAPI<?>> {
         return params.size();
     }
 
+    public boolean equals(Object other) {
+        if (other instanceof ParameterList)
+            return equalsParameterList((ParameterList)other);
+
+        return false;
+    }
+
     /**
      * Returns true if all the parameters have the same names and values. One
      * use will be to determine if two DisctetizedFunctions are the same, i.e.
      * set up with the same independent parameters.
      */
-    public boolean equals(ParameterList list) {
+    public boolean equalsParameterList(ParameterList list) {
 
         // Not same size, can't be equal
         if (this.size() != list.size())

--- a/java_tests/org/opensha/commons/data/DataSuite.java
+++ b/java_tests/org/opensha/commons/data/DataSuite.java
@@ -25,7 +25,8 @@ import org.opensha.commons.geo.RegionTest;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ DataPoint2DTests.class, DataPoint2DTreeMapTests.class,
-        TimeSpanTests.class, GriddedRegionTest.class, RegionTest.class })
+            TimeSpanTests.class, GriddedRegionTest.class, RegionTest.class,
+            SiteTests.class})
 public class DataSuite {
 
     public static void main(String args[]) {

--- a/java_tests/org/opensha/commons/data/SiteTests.java
+++ b/java_tests/org/opensha/commons/data/SiteTests.java
@@ -46,4 +46,36 @@ public class SiteTests {
         assertThat(s12_2a, is(not(equalTo(s12_1))));
         assertThat(s12_1,  is(not(equalTo(s12_2a))));
     }
+
+    @Test
+    public void checkSitesHashing() {
+        Object s21_1  = new Site(new Location(2.0, 1.0));
+        Object s21_2  = new Site(new Location(2.0, 1.0));
+        Object s12_1  = new Site(new Location(1.0, 2.0));
+        Object s12_2  = new Site(new Location(1.0, 2.0));
+        Object s12_2a = new Site(new Location(1.0, 2.0), "a");
+        Object s12_3a = new Site(new Location(1.0, 2.0), "a");
+
+        // this is more a sanity test than a real test
+        assertThat(s21_1.hashCode(),  is(equalTo(s21_2.hashCode())));
+        assertThat(s12_1.hashCode(),  is(equalTo(s12_2.hashCode())));
+        assertThat(s12_2a.hashCode(), is(equalTo(s12_3a.hashCode())));
+    }
+
+    @Test
+    public void checkHashMap() {
+        HashMap<Site, Integer> map = new HashMap<Site, Integer>();
+
+        for (int i = -90, k = 0; i < 90; ++i)
+            for (int j = -90; j < 90; ++j, ++k)
+                map.put(new Site(new Location(i, j)), k);
+
+        for (int i = -90, k = 0; i < 90; ++i)
+            for (int j = -90; j < 90; ++j, ++k)
+            {
+                int value = map.remove(new Site(new Location(i, j)));
+
+                assertThat(k, is(equalTo(value)));
+            }
+    }
 }

--- a/java_tests/org/opensha/commons/data/SiteTests.java
+++ b/java_tests/org/opensha/commons/data/SiteTests.java
@@ -1,0 +1,49 @@
+package org.opensha.commons.data;
+
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import static org.junit.matchers.JUnitMatchers.*;
+
+import static org.hamcrest.CoreMatchers.*;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.geo.Location;
+
+public class SiteTests {
+
+    /**
+     * Check that sites equality works as expected
+     */
+    @Test
+    public void checkSitesEquality() {
+        Object s21_1  = new Site(new Location(2.0, 1.0));
+        Object s21_2  = new Site(new Location(2.0, 1.0));
+        Object s12_3a = new Site(new Location(1.0, 2.0), "a");
+        Object s12_1  = new Site(new Location(1.0, 2.0));
+        Object s12_2a = new Site(new Location(1.0, 2.0), "a");
+        Object s12_3b = new Site(new Location(1.0, 2.0), "b");
+        Object s12_4a = new Site(new Location(1.0, 2.0), "a");
+
+        // same coordinates, null names
+        assertThat(s21_1,  is(equalTo(s21_1)));
+        assertThat(s21_1,  is(equalTo(s21_2)));
+        // different coordinates, null names
+        assertThat(s21_1,  is(not(equalTo(s12_1))));
+        assertThat(s12_1,  is(not(equalTo(s21_1))));
+        // same coordinates, same name
+        assertThat(s12_2a, is(equalTo(s12_4a)));
+        assertThat(s12_4a, is(equalTo(s12_2a)));
+        // same coordinates, different names
+        assertThat(s12_2a, is(not(equalTo(s12_3b))));
+        assertThat(s12_3b, is(not(equalTo(s12_2a))));
+        // one name null, the other not null
+        assertThat(s12_2a, is(not(equalTo(s12_1))));
+        assertThat(s12_1,  is(not(equalTo(s12_2a))));
+    }
+}


### PR DESCRIPTION
Fixed hashCode() to be consistent with the equality check.
Fixed the equality check to handle the case where name is null.

Addresses https://bugs.launchpad.net/openquake/+bug/820961
