### PR TITLE
Refactored VS30 type constants into an enum

### DIFF
--- a/java/org/opensha/sha/imr/attenRelImpl/AS_2008_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/AS_2008_AttenRel.java
@@ -63,6 +63,7 @@ import org.opensha.sha.imr.param.PropagationEffectParams.HangingWallFlagParam;
 import org.opensha.sha.imr.param.SiteParams.DepthTo1pt0kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam;
+import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam.Vs30Type;
 
 /**
  * <b>Title:</b> AS_2008_AttenRel
@@ -1478,7 +1479,7 @@ public class AS_2008_AttenRel extends AttenuationRelationship implements
         } else if (pName.equals(Vs30_Param.NAME)) {
             vs30 = ((Double) val).doubleValue();
         } else if (pName.equals(Vs30_TypeParam.NAME)) {
-            if (((String) val).equals(Vs30_TypeParam.VS30_TYPE_MEASURED)) {
+            if (((String) val).equals(Vs30Type.Measured.toString())) {
                 vsm = 1;
             } else {
                 vsm = 0;

--- a/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
@@ -56,6 +56,7 @@ import org.opensha.sha.imr.param.PropagationEffectParams.HangingWallFlagParam;
 import org.opensha.sha.imr.param.SiteParams.DepthTo1pt0kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam;
+import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam.Vs30Type;
 
 /**
  * <b>Title:</b> CY_2006_AttenRel
@@ -516,7 +517,7 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 		aftershockParam.setValueAsDefault();
 
 		vs30Param.setValueAsDefault();
-		vs30_TypeParam.setValue(Vs30_TypeParam.VS30_TYPE_INFERRED);
+		vs30_TypeParam.setValue(Vs30Type.Inferred.toString());
 		depthTo1pt0kmPerSecParam.setValueAsDefault();
 
 		distanceRupParam.setValueAsDefault();
@@ -992,7 +993,7 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 		} else if (pName.equals(Vs30_Param.NAME)) {
 			vs30 = ((Double) val).doubleValue();
 		} else if (pName.equals(Vs30_TypeParam.NAME)) {
-			if (((String) val).equals(Vs30_TypeParam.VS30_TYPE_MEASURED)) {
+			if (((String) val).equals(Vs30Type.Measured.toString())) {
 				f_meas = 1; // Bob Youngs confirmed by email that this is
 							// correct (f_meas=1-f_inf)
 			} else {

--- a/java/org/opensha/sha/imr/param/SiteParams/Vs30_TypeParam.java
+++ b/java/org/opensha/sha/imr/param/SiteParams/Vs30_TypeParam.java
@@ -32,8 +32,10 @@ public class Vs30_TypeParam extends StringParameter {
     public final static String NAME = "Vs30 Type";
     public final static String INFO = "Indicates how Vs30 was obtained";
     // Options for constraint:
-    public final static String VS30_TYPE_MEASURED = "Measured";
-    public final static String VS30_TYPE_INFERRED = "Inferred";
+    public static enum Vs30Type {
+        Measured,
+        Inferred,
+    }
 
     /**
      * This provides maximum flexibility in terms of setting the options and the
@@ -53,13 +55,14 @@ public class Vs30_TypeParam extends StringParameter {
     public Vs30_TypeParam() {
         super(NAME);
         StringConstraint options = new StringConstraint();
-        options.addString(VS30_TYPE_MEASURED);
-        options.addString(VS30_TYPE_INFERRED);
+        for (Vs30Type t : Vs30Type.values()) {
+            options.addString(t.toString());
+        }
         options.setNonEditable();
-        setValue(VS30_TYPE_INFERRED); // need to do this so next line succeeds
+        setValue(Vs30Type.Inferred.toString()); // need to do this so next line succeeds
         setConstraint(options);
         setInfo(INFO);
-        setDefaultValue(VS30_TYPE_INFERRED);
+        setDefaultValue(Vs30Type.Inferred.toString());
         setNonEditable();
     }
 }

--- a/java_tests/org/opensha/sha/imr/attenRelImpl/test/AS_2008_test.java
+++ b/java_tests/org/opensha/sha/imr/attenRelImpl/test/AS_2008_test.java
@@ -50,6 +50,7 @@ import org.opensha.sha.imr.param.PropagationEffectParams.HangingWallFlagParam;
 import org.opensha.sha.imr.param.SiteParams.DepthTo1pt0kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam;
+import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam.Vs30Type;
 
 public class AS_2008_test extends NGATest {
 
@@ -212,10 +213,10 @@ public class AS_2008_test extends NGATest {
 
         if (fileName.contains("SIGEST"))
             as_2008.getParameter(Vs30_TypeParam.NAME).setValue(
-                    Vs30_TypeParam.VS30_TYPE_INFERRED);
+                    Vs30Type.Inferred.toString());
         else
             as_2008.getParameter(Vs30_TypeParam.NAME).setValue(
-                    Vs30_TypeParam.VS30_TYPE_MEASURED);
+                    Vs30Type.Measured.toString());
 
         try {
             testDataLines = FileUtils.loadFile(file.getAbsolutePath());

--- a/java_tests/org/opensha/sha/imr/attenRelImpl/test/CY_2008_test.java
+++ b/java_tests/org/opensha/sha/imr/attenRelImpl/test/CY_2008_test.java
@@ -50,6 +50,7 @@ import org.opensha.sha.imr.param.PropagationEffectParams.HangingWallFlagParam;
 import org.opensha.sha.imr.param.SiteParams.DepthTo1pt0kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam;
+import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam.Vs30Type;
 
 public class CY_2008_test extends NGATest {
 
@@ -155,10 +156,10 @@ public class CY_2008_test extends NGATest {
 
         if (fileName.contains("SIGMEAS"))
             cy_08.getParameter(Vs30_TypeParam.NAME).setValue(
-                    Vs30_TypeParam.VS30_TYPE_MEASURED);
+                    Vs30Type.Measured.toString());
         else
             cy_08.getParameter(Vs30_TypeParam.NAME).setValue(
-                    Vs30_TypeParam.VS30_TYPE_INFERRED);
+                    Vs30Type.Inferred.toString());
 
         try {
             ArrayList<String> testDataLines =

--- a/java_tests/org/opensha/sha/imr/attenRelImpl/test/NGA08_Site_EqkRup_Tests.java
+++ b/java_tests/org/opensha/sha/imr/attenRelImpl/test/NGA08_Site_EqkRup_Tests.java
@@ -50,6 +50,7 @@ import org.opensha.sha.imr.param.SiteParams.DepthTo1pt0kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.DepthTo2pt5kmPerSecParam;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam;
+import org.opensha.sha.imr.param.SiteParams.Vs30_TypeParam.Vs30Type;
 
 /**
  * This tests whether the 2008 NGA attenuation relationships get their Site-,
@@ -69,7 +70,7 @@ public class NGA08_Site_EqkRup_Tests {
     // hard-coded test values (just make sure they aren't equal to defaults in
     // atten relationships)
     double mag = 6.345, vs30 = 551.2, depth2pt5 = 8.134, depth1pt0 = 1111.1;
-    String vs30_type = Vs30_TypeParam.VS30_TYPE_INFERRED;
+    String vs30_type = Vs30Type.Inferred.toString();
     Boolean aftershock = new Boolean(false);
 
     double[] distX;


### PR DESCRIPTION
Needed for some changes in the OpenQuake java code base to fix this bug: https://bugs.launchpad.net/openquake/+bug/887577

Basically, we want to do some VS30 type validation in the OpenQuake Disaggregation calculator. In the future, we may add support for new VS30 types; changing the two constants for 'Measured' and 'Inferred' to an enum allows us to write a generic validator that loops over the enum values (and we don't have to update the check code if the enum is changed).
