### PR TITLE
Remove status bar calculation in Hazard Curve Calculator

### DIFF
--- a/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -37,11 +37,8 @@ import org.opensha.sha.earthquake.EqkRupForecastAPI;
 import org.opensha.sha.earthquake.EqkRupture;
 import org.opensha.sha.earthquake.ProbEqkRupture;
 import org.opensha.sha.earthquake.ProbEqkSource;
-// import
-// org.opensha.sha.earthquake.rupForecastImpl.Frankel96.Frankel96_EqkRupForecast;
 import org.opensha.sha.imr.AttenuationRelationship;
 import org.opensha.sha.imr.ScalarIntensityMeasureRelationshipAPI;
-// import org.opensha.sha.imr.attenRelImpl.BJF_1997_AttenRel;
 import org.opensha.sha.util.TRTUtils;
 import org.opensha.sha.util.TectonicRegionType;
 
@@ -309,9 +306,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
                     EqkRupForecastAPI eqkRupForecast)
                     throws java.rmi.RemoteException {
 
-        // System.out.println("Haz Curv Calc: maxDistanceParam.getValue()="+maxDistanceParam.getValue().toString());
-        // System.out.println("Haz Curv Calc: numStochEventSetRealizationsParam.getValue()="+numStochEventSetRealizationsParam.getValue().toString());
-        // System.out.println("Haz Curv Calc: includeMagDistFilterParam.getValue()="+includeMagDistFilterParam.getValue().toString());
         if (includeMagDistFilterParam.getValue())
             System.out.println("Haz Curv Calc: magDistCutoffParam.getValue()="
                     + magDistCutoffParam.getValue().toString());
@@ -319,7 +313,7 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         this.currRuptures = -1;
 
         /*
-         * this determines how the calucations are done (doing it the way it's
+         * this determines how the calculations are done (doing it the way it's
          * outlined in our original SRL paper gives probs greater than 1 if the
          * total rate of events for the source exceeds 1.0, even if the rates of
          * individual ruptures are << 1).
@@ -331,7 +325,7 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         ArbitrarilyDiscretizedFunc sourceHazFunc =
                 (ArbitrarilyDiscretizedFunc) hazFunction.deepClone();
 
-        // declare some varibles used in the calculation
+        // declare some variables used in the calculation
         double qkProb, distance;
         int k;
 
@@ -353,9 +347,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
 
         // get total number of sources
         numSources = eqkRupForecast.getNumSources();
-        // System.out.println("Number of Sources: "+numSources);
-        // System.out.println("ERF info: "+
-        // eqkRupForecast.getClass().getName());
 
         // init the current rupture number (also for progress bar)
         currRuptures = 0;
@@ -393,7 +384,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
                                                          // for skipped ruptures
                 continue;
             }
-            // System.out.println(" dist: " + distance);
 
             // get magThreshold if we're to use the mag-dist cutoff filter
             if (includeMagDistFilter) {
@@ -487,8 +477,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         if (D)
             System.out.println(C + "hazFunction.toString"
                     + hazFunction.toString());
-
-        // System.out.println("numRupRejected="+numRupRejected);
 
         return hazFunction;
     }
@@ -622,8 +610,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         if (D)
             System.out.println(C + ": starting hazard curve calculation");
 
-        // System.out.println("totRuptures="+totRuptures);
-
         // loop over ruptures
         for (int n = 0; n < totRups; n++) {
 
@@ -631,14 +617,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
                 ++currRuptures;
 
             EqkRupture rupture = eqkRupList.get(n);
-
-            /*
-             * // apply mag-dist cutoff filter if(includeMagDistFilter) {
-             * //distance=??; // NEED TO COMPUTE THIS DISTANCE
-             * if(rupture.getMag() <
-             * magDistCutoffParam.getValue().getInterpolatedY(distance) {
-             * numRupRejected += 1; continue; }
-             */
 
             // set the EqkRup in the IMR
             imr.setEqkRupture(rupture);
@@ -656,15 +634,9 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
 
         }
 
-        // System.out.println(C+"hazFunction.toString"+hazFunction.toString());
-
         // now convert from total non-exceed prob to total exceed prob
         for (int i = 0; i < numPoints; ++i)
             hazFunction.set(i, 1.0 - hazFunction.getY(i));
-
-        // System.out.println(C+"hazFunction.toString"+hazFunction.toString());
-
-        // System.out.println("numRupRejected="+numRupRejected);
 
         return hazFunction;
     }

--- a/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -120,7 +120,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
 
     // misc counting and index variables
     protected int currRuptures = -1;
-    protected int totRuptures = 0;
     protected int sourceIndex;
     protected int numSources;
 
@@ -363,14 +362,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         // System.out.println("ERF info: "+
         // eqkRupForecast.getClass().getName());
 
-        // compute the total number of ruptures for updating the progress bar
-        totRuptures = 0;
-        sourceIndex = 0;
-        for (sourceIndex = 0; sourceIndex < numSources; ++sourceIndex)
-            totRuptures +=
-                    eqkRupForecast.getSource(sourceIndex).getNumRuptures();
-        // System.out.println("Total number of ruptures:"+ totRuptures);
-
         // init the current rupture number (also for progress bar)
         currRuptures = 0;
         int numRupRejected = 0;
@@ -560,10 +551,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
 
         for (int i = 0; i < numEventSets; i++) {
             ArrayList<EqkRupture> events = eqkRupForecast.drawRandomEventSet();
-            if (i == 0)
-                totRuptures = events.size() * numEventSets; // this is an
-                                                            // approximate total
-                                                            // number of events
             currRuptures += events.size();
             getEventSetHazardCurve(hazCurve, site, imr, events, false);
             for (int x = 0; x < numPts; x++)
@@ -631,7 +618,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
         int totRups = eqkRupList.size();
         // progress bar stuff
         if (updateCurrRuptures) {
-            totRuptures = totRups;
             currRuptures = 0;
         }
 
@@ -762,16 +748,6 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
      */
     public int getCurrRuptures() throws java.rmi.RemoteException {
         return this.currRuptures;
-    }
-
-    /**
-     * 
-     * @returns the total number of ruptures in the earthquake rupture forecast
-     *          model
-     * @throws java.rmi.RemoteException
-     */
-    public int getTotRuptures() throws java.rmi.RemoteException {
-        return this.totRuptures;
     }
 
     /**

--- a/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -521,7 +521,7 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
 
         for (int i = 0; i < numEventSets; i++) {
             ArrayList<EqkRupture> events = eqkRupForecast.drawRandomEventSet();
-            getEventSetHazardCurve(hazCurve, site, imr, events, false);
+            getEventSetHazardCurve(hazCurve, site, imr, events);
             for (int x = 0; x < numPts; x++)
                 hazFunction.set(x, hazFunction.getY(x) + hazCurve.getY(x));
         }
@@ -549,15 +549,12 @@ public class HazardCurveCalculator extends UnicastRemoteObject implements
      *            : selected IMR object
      * @param eqkRupForecast
      *            : selected Earthquake rup forecast
-     * @param updateCurrRuptures
-     *            : tells whether to update current ruptures (for the
-     *            getCurrRuptures() method used for progress bars)
      * @return
      */
     public DiscretizedFuncAPI getEventSetHazardCurve(
             DiscretizedFuncAPI hazFunction, Site site,
             ScalarIntensityMeasureRelationshipAPI imr,
-            ArrayList<EqkRupture> eqkRupList, boolean updateCurrRuptures)
+            ArrayList<EqkRupture> eqkRupList)
             throws java.rmi.RemoteException {
 
         ArbitrarilyDiscretizedFunc condProbFunc =

--- a/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
@@ -243,15 +243,12 @@ public interface HazardCurveCalculatorAPI extends Remote {
      *            : selected IMR object
      * @param eqkRupForecast
      *            : selected Earthquake rup forecast
-     * @param updateCurrRuptures
-     *            : tells whether to update current ruptures (for the
-     *            getCurrRuptures() method used for progress bars)
      * @return
      */
     public DiscretizedFuncAPI getEventSetHazardCurve(
             DiscretizedFuncAPI hazFunction, Site site,
             ScalarIntensityMeasureRelationshipAPI imr,
-            ArrayList<EqkRupture> eqkRupList, boolean updateCurrRuptures)
+            ArrayList<EqkRupture> eqkRupList)
             throws java.rmi.RemoteException;
 
 }

--- a/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
@@ -193,9 +193,6 @@ public interface HazardCurveCalculatorAPI extends Remote {
     // gets the current rupture that is being processed
     public int getCurrRuptures() throws java.rmi.RemoteException;
 
-    // gets the total number of ruptures.
-    public int getTotRuptures() throws java.rmi.RemoteException;
-
     /**
      * stops the Hazard Curve calculations.
      * 

--- a/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
+++ b/java/org/opensha/sha/calc/HazardCurveCalculatorAPI.java
@@ -190,9 +190,6 @@ public interface HazardCurveCalculatorAPI extends Remote {
             Site site, ScalarIntensityMeasureRelationshipAPI imr,
             EqkRupture rupture) throws java.rmi.RemoteException;
 
-    // gets the current rupture that is being processed
-    public int getCurrRuptures() throws java.rmi.RemoteException;
-
     /**
      * stops the Hazard Curve calculations.
      * 


### PR DESCRIPTION
Addresses: https://bugs.launchpad.net/openquake/+bug/888067

This patch basically just removes some redundant code, in an effort to make OpenSHA-lite more lean.

I've tested this code with the latest OpenQuake code. All unit and QA tests pass.
