### PR TITLE
Suppress useless debugging prints (s/D = true/D = false/g)

### DIFF
--- a/java/org/opensha/commons/data/function/ArbitrarilyDiscretizedFunc.java
+++ b/java/org/opensha/commons/data/function/ArbitrarilyDiscretizedFunc.java
@@ -64,7 +64,7 @@ public class ArbitrarilyDiscretizedFunc extends DiscretizedFunc implements
     protected final static String C = "ArbitrarilyDiscretizedFunc";
 
     /* Boolean debugging variable to switch on and off debug printouts */
-    protected final static boolean D = true;
+    protected final static boolean D = false;
 
     /**
      * The set of DataPoints2D that conprise the discretized function. These are

--- a/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
@@ -1353,7 +1353,7 @@ public class AS_1997_AttenRel extends AttenuationRelationship implements
     class AS_1997_AttenRelCoefficients implements NamedObjectAPI {
 
         protected final static String C = "AS_1997_AttenRelCoefficients";
-        protected final static boolean D = true;
+        protected final static boolean D = false;
 
         /** For serialization. */
         private static final long serialVersionUID = 1234567890987654322L;

--- a/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
@@ -1168,7 +1168,7 @@ public class Abrahamson_2000_AttenRel extends AttenuationRelationship implements
 
         protected final static String C =
                 "Abrahamson_2000_AttenRelCoefficients";
-        protected final static boolean D = true;
+        protected final static boolean D = false;
 
         /** For serialization. */
         private static final long serialVersionUID = 1234567890987654321L;

--- a/java/org/opensha/sha/imr/attenRelImpl/CB_2003_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/CB_2003_AttenRel.java
@@ -1175,7 +1175,7 @@ public class CB_2003_AttenRel extends AttenuationRelationship implements
         /** For serialization. */
         private static final long serialVersionUID = 1234567890987654325L;
         protected final static String C = "CB_2003_AttenRelCoefficients";
-        protected final static boolean D = true;
+        protected final static boolean D = false;
 
         protected String name;
         protected double period = -1;

--- a/java/org/opensha/sha/imr/attenRelImpl/Campbell_1997_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/Campbell_1997_AttenRel.java
@@ -1048,7 +1048,7 @@ public class Campbell_1997_AttenRel extends AttenuationRelationship implements
     class Campbell_1997_AttenRelCoefficients implements NamedObjectAPI {
 
         protected final static String C = "Campbell_1997_AttenRelCoefficients";
-        protected final static boolean D = true;
+        protected final static boolean D = false;
         /** For serialization. */
         private static final long serialVersionUID = 1234567890987654324L;
 

--- a/java/org/opensha/sha/imr/attenRelImpl/SadighEtAl_1997_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/SadighEtAl_1997_AttenRel.java
@@ -760,7 +760,7 @@ NamedObjectAPI {
 		 */
 
 		protected final static String C = "SCEMY_1997_AttenRelCoefficients";
-		protected final static boolean D = true;
+		protected final static boolean D = false;
 		/** For serialization. */
 		private static final long serialVersionUID = 1234567890987654328L;
 

--- a/java/org/opensha/sha/imr/param/PropagationEffectParams/DistanceX_Parameter.java
+++ b/java/org/opensha/sha/imr/param/PropagationEffectParams/DistanceX_Parameter.java
@@ -55,7 +55,7 @@ public class DistanceX_Parameter extends
     /** Class name used in debug strings */
     protected final static String C = "DistanceJBParameter";
     /** If true debug statements are printed out */
-    protected final static boolean D = true;
+    protected final static boolean D = false;
 
     /** Hardcoded name */
     public final static String NAME = "DistanceX";


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/888013
