### PR TITLE
Complex fault demo NullPointerException fix

### DIFF
--- a/java/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSource.java
+++ b/java/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSource.java
@@ -18,7 +18,6 @@
 
 package org.opensha.sha.earthquake.rupForecastImpl;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -26,17 +25,14 @@ import org.opensha.commons.calc.magScalingRelations.MagAreaRelationship;
 import org.opensha.commons.calc.magScalingRelations.MagLengthRelationship;
 import org.opensha.commons.calc.magScalingRelations.MagScalingRelationship;
 import org.opensha.commons.data.Site;
-import org.opensha.commons.util.FileUtils;
 import org.opensha.commons.geo.BorderType;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.LocationList;
-import org.opensha.commons.geo.LocationUtils;
 import org.opensha.commons.geo.Region;
 import org.opensha.sha.earthquake.ProbEqkRupture;
 import org.opensha.sha.earthquake.ProbEqkSource;
 import org.opensha.sha.faultSurface.EvenlyGriddedSurface;
 import org.opensha.sha.faultSurface.EvenlyGriddedSurfaceAPI;
-import org.opensha.sha.faultSurface.FaultTrace;
 import org.opensha.sha.magdist.GaussianMagFreqDist;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import org.opensha.sha.util.TectonicRegionType;
@@ -118,7 +114,7 @@ import org.opensha.sha.util.TectonicRegionType;
 public class FloatingPoissonFaultSource extends ProbEqkSource {
 
     // for Debug purposes
-    private static String C = new String("FloatingPoissonFaultSource");
+    private static String C = "FloatingPoissonFaultSource";
     private boolean D = false;
 
     // name for this classs
@@ -127,8 +123,6 @@ public class FloatingPoissonFaultSource extends ProbEqkSource {
     // private fields
     private ArrayList<ProbEqkRupture> ruptureList;
 
-    // private ArrayList<Location> faultCornerLocations = new
-    // ArrayList<Location>(); // used for the getMinDistance(Site) method
     private double duration;
     private EvenlyGriddedSurface faultSurface;
 
@@ -278,6 +272,7 @@ public class FloatingPoissonFaultSource extends ProbEqkSource {
     	for (int r = 0; r < ruptureList.size(); r++) {
     		ruptureList.get(r).setTectRegType(tectRegType);
     	}
+    	super.setTectonicRegionType(tectRegType);
     }
 
     /**
@@ -364,8 +359,6 @@ public class FloatingPoissonFaultSource extends ProbEqkSource {
                         rupWidth = 2 * ddw; // factor of 2 more than ensures
                                             // full ddw ruptures
 
-                    // System.out.println((float)mag+"\t"+(float)rupLen+"\t"+(float)rupWidth+"\t"+(float)(rupLen*rupWidth));
-
                     // get number of ruptures depending on whether we're
                     // floating down the middle
                     if (floatTypeFlag != 2)
@@ -403,14 +396,6 @@ public class FloatingPoissonFaultSource extends ProbEqkSource {
                         		rupSurf.getSurfaceCentre());
                         ruptureList.add(probEqkRupture);
                     }
-                    /*
-                     * if( D )
-                     * System.out.println(C+": ddw="+ddw+": mag="+mag+"; rupLen="
-                     * +rupLen+"; rupWidth="+rupWidth+
-                     * "; rate="+rate+"; timeSpan="+duration+"; numRup="+numRup+
-                     * "; weight="
-                     * +weight+"; prob="+prob+"; floatTypeFlag="+floatTypeFlag);
-                     */
 
                 }
                 // Apply full fault rupture

--- a/java_tests/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSourceTest.java
+++ b/java_tests/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSourceTest.java
@@ -240,6 +240,19 @@ public class FloatingPoissonFaultSourceTest {
 		return expectedResults;
 	}
 
+	/**
+	 * This test was introduced as a results of this bug report:
+	 * https://bugs.launchpad.net/openquake/+bug/901092
+	 * 
+	 * FloatingPoissonFaultSource overrides the setTectonicRegionType
+	 * method from the base class (ProbEqkSource).
+	 * 
+	 * However, the override fails to do what the base implementation
+	 * does: set the tectonic region type.
+	 * 
+	 * I wonder how long this bug has been here, and why we found
+	 * it just now.
+	 */
 	@Test
 	public void testSetTectonicRegionTypeActuallySetsTectonicRegionType() {
 	    FloatingPoissonFaultSource src =

--- a/java_tests/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSourceTest.java
+++ b/java_tests/org/opensha/sha/earthquake/rupForecastImpl/FloatingPoissonFaultSourceTest.java
@@ -239,4 +239,15 @@ public class FloatingPoissonFaultSourceTest {
 
 		return expectedResults;
 	}
+
+	@Test
+	public void testSetTectonicRegionTypeActuallySetsTectonicRegionType() {
+	    FloatingPoissonFaultSource src =
+	            FloatingPoissonFaultSourceTestHelper.getPeerTestSet1Case5FaultSource();
+	    // We assume the default is ACTIVE_SHALLOW
+	    assertEquals(TectonicRegionType.ACTIVE_SHALLOW, src.getTectonicRegionType());
+
+	    src.setTectonicRegionType(TectonicRegionType.SUBDUCTION_INTERFACE);
+	    assertEquals(TectonicRegionType.SUBDUCTION_INTERFACE, src.getTectonicRegionType());
+	}
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/openquake/+bug/901092

Basically, the `setTectonicRegionType` method of `ProbEqkSource` was being overridden by `FloatingPoissonFaultSource`... the override wasn't ACTUALLY setting the tectonic region type.

I also did a little bit of house cleaning: deleted commented code, fixed a few FindBugs issues, etc.
