### PR TITLE
Fix for CY_2008 GMPE SA param NullPointerException

### DIFF
--- a/java/org/opensha/commons/param/DoubleConstraint.java
+++ b/java/org/opensha/commons/param/DoubleConstraint.java
@@ -49,9 +49,9 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
     protected final static boolean D = false;
 
     /** The minimum value allowed in this constraint, inclusive */
-    protected Double min = null;
+    protected double min;
     /** The maximum value allowed in this constraint, inclusive */
-    protected Double max = null;
+    protected double max;
 
     /** No-Arg Constructor, constraints are null so all values allowed */
     public DoubleConstraint() {
@@ -61,7 +61,7 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
     /**
      * Constructor for the DoubleConstraint object. Sets the min and max values
      * allowed in this constraint. No checks are performed that min and max are
-     * consistant with each other.
+     * consistent with each other.
      * 
      * @param min
      *            The min value allowed
@@ -69,21 +69,6 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
      *            The max value allowed
      */
     public DoubleConstraint(double min, double max) {
-        this.min = new Double(min);
-        this.max = new Double(max);
-    }
-
-    /**
-     * Constructor for the DoubleConstraint object. Sets the min and max values
-     * allowed in this constraint. No checks are performed that min and max are
-     * consistant with each other.
-     * 
-     * @param min
-     *            The min value allowed
-     * @param max
-     *            The max value allowed
-     */
-    public DoubleConstraint(Double min, Double max) {
         this.min = min;
         this.max = max;
     }
@@ -102,25 +87,6 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
      */
     public void setMinMax(double min, double max) throws EditableException {
         String S = C + ": setMinMax(double, double): ";
-        checkEditable(S);
-        this.min = new Double(min);
-        this.max = new Double(max);
-    }
-
-    /**
-     * Sets the min and max values allowed in this constraint. No checks are
-     * performed that min and max are consistant with each other.
-     * 
-     * @param min
-     *            The new min value
-     * @param max
-     *            The new max value
-     * @throws EditableException
-     *             Thrown when the constraint or parameter containing this
-     *             constraint has been made non-editable.
-     */
-    public void setMinMax(Double min, Double max) throws EditableException {
-        String S = C + ": setMinMax(Double, Double): ";
         checkEditable(S);
         this.min = min;
         this.max = max;
@@ -150,12 +116,13 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
      */
     public boolean isAllowed(Double d) {
         if (d == null)
+        {
             return nullAllowed;
-        if ((min == null) || (max == null))
-            return true;
-        else if ((d.compareTo(min) >= 0) && (d.compareTo(max) <= 0))
-            return true;
-        return false;
+        }
+        else
+        {
+            return isAllowed((double)d);
+        }
     }
 
     /**
@@ -170,7 +137,7 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
      * @return True if this is one of the allowed values.
      */
     public boolean isAllowed(double d) {
-        return isAllowed(new Double(d));
+        return d >= min && d <= max;
     }
 
     /**
@@ -182,10 +149,8 @@ public class DoubleConstraint extends ParameterConstraint<Double> {
         StringBuffer b = new StringBuffer();
         if (name != null)
             b.append(TAB + "Name = " + name + '\n');
-        if (min != null)
-            b.append(TAB + "Min = " + min.toString() + '\n');
-        if (max != null)
-            b.append(TAB + "Max = " + max.toString() + '\n');
+        b.append(TAB + "Min = " + String.valueOf(min) + '\n');
+        b.append(TAB + "Max = " + String.valueOf(max) + '\n');
         b.append(TAB + "Null Allowed = " + this.nullAllowed + '\n');
         return b.toString();
     }

--- a/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
@@ -1041,6 +1041,7 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 		hangingWallFlagParam.removeParameterChangeListener(this);
 		stdDevTypeParam.removeParameterChangeListener(this);
 		saPeriodParam.removeParameterChangeListener(this);
+		saParam.removeParameterChangeListener(this);
 		this.initParameterEventListeners();
 	}
 
@@ -1064,6 +1065,7 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 		hangingWallFlagParam.addParameterChangeListener(this);
 		stdDevTypeParam.addParameterChangeListener(this);
 		saPeriodParam.addParameterChangeListener(this);
+		saParam.addParameterChangeListener(this);
 	}
 
 	/**

--- a/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
+++ b/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
@@ -269,7 +269,6 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 			depthTop;
 	private double distRupMinusDistX_OverRup, aftershock, f_meas, f_hw;
 	private String stdDevType;
-	private boolean parameterChange;
 	private double depthTo1pt0kmPerSec; // defined this way to support null
 										// values
 	private double lnYref;
@@ -460,7 +459,6 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 		else
 			iper = 23; // PGV
 
-		parameterChange = true;
 		intensityMeasureChanged = false;
 
 	}
@@ -963,11 +961,10 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 
 		String pName = e.getParameterName();
 		Object val = e.getNewValue();
-		parameterChange = true;
 		lnYref_is_not_fresh = true; // this could be placed below, only where
 									// really needed.
 
-		if (pName.equals(magParam.NAME)) {
+		if (pName.equals(MagParam.NAME)) {
 			mag = ((Double) val).doubleValue();
 		} else if (pName.equals(FaultTypeParam.NAME)) {
 			String fltType = (String) fltTypeParam.getValue();

--- a/java/org/opensha/sha/imr/param/IntensityMeasureParams/SA_Param.java
+++ b/java/org/opensha/sha/imr/param/IntensityMeasureParams/SA_Param.java
@@ -36,11 +36,10 @@ public class SA_Param extends WarningDoubleParameter {
     public final static String NAME = "SA";
     public final static String UNITS = "g";
     public final static String INFO = "Response Spectral Acceleration";
-    protected final static Double MIN = new Double(Math.log(Double.MIN_VALUE));
-    protected final static Double MAX = new Double(Double.MAX_VALUE);
-    protected final static Double DEFAULT_WARN_MIN = new Double(
-            Math.log(Double.MIN_VALUE));
-    protected final static Double DEFAULT_WARN_MAX = new Double(Math.log(10.0));
+    protected final static Double MIN = Math.log(Double.MIN_VALUE);
+    protected final static Double MAX = Double.MAX_VALUE;
+    protected final static Double DEFAULT_WARN_MIN = Math.log(Double.MIN_VALUE);
+    protected final static Double DEFAULT_WARN_MAX = Math.log(Double.MAX_VALUE);
 
     /**
      * This uses the DEFAULT_WARN_MIN and DEFAULT_WARN_MAX fields to set the

--- a/java/org/opensha/sha/imr/param/IntensityMeasureParams/SA_Param.java
+++ b/java/org/opensha/sha/imr/param/IntensityMeasureParams/SA_Param.java
@@ -40,7 +40,7 @@ public class SA_Param extends WarningDoubleParameter {
     protected final static Double MAX = new Double(Double.MAX_VALUE);
     protected final static Double DEFAULT_WARN_MIN = new Double(
             Math.log(Double.MIN_VALUE));
-    protected final static Double DEFAULT_WARN_MAX = new Double(Math.log(3.0));
+    protected final static Double DEFAULT_WARN_MAX = new Double(Math.log(10.0));
 
     /**
      * This uses the DEFAULT_WARN_MIN and DEFAULT_WARN_MAX fields to set the

--- a/java_tests/org/opensha/commons/param/WarningDoubleParameterTest.java
+++ b/java_tests/org/opensha/commons/param/WarningDoubleParameterTest.java
@@ -1,0 +1,63 @@
+package org.opensha.commons.param;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensha.commons.param.event.ParameterChangeWarningEvent;
+import org.opensha.commons.param.event.ParameterChangeWarningListener;
+
+public class WarningDoubleParameterTest
+{
+
+    private WarningDoubleParameter wdp;
+    private ParameterChangeWarningListener listener;
+
+    @Before
+    public void setUp()
+    {
+        wdp = new WarningDoubleParameter("Test");
+        listener = new ParameterChangeWarningListener()
+        {
+            public void parameterChangeWarning(ParameterChangeWarningEvent event){}
+
+        };
+    }
+    /**
+     * Test addParameterChangeWarningListener with null input.
+     * 
+     * If the input is null, it should simply be ignored.
+     */
+    @Test
+    public void testAddNullPCWL()
+    {
+        assertNull(wdp.getWarningListeners());
+
+        wdp.addParameterChangeWarningListener(null);
+        // It should still be null.
+        assertNull(wdp.getWarningListeners());
+
+        // Add a real listener.
+        wdp.addParameterChangeWarningListener(listener);
+        assertEquals(1, wdp.getWarningListeners().size());
+        assertEquals(listener, wdp.getWarningListeners().get(0));
+
+        // Now try to add a null; the current list should be unaffected.
+        wdp.addParameterChangeWarningListener(null);
+        assertEquals(1, wdp.getWarningListeners().size());
+        assertEquals(listener, wdp.getWarningListeners().get(0));
+    }
+
+    /**
+     * Test addParameterChangeWarningListener with normal input.
+     */
+    @Test
+    public void testAddPCWL()
+    {
+        assertNull(wdp.getWarningListeners());
+
+        wdp.addParameterChangeWarningListener(listener);
+        assertEquals(1, wdp.getWarningListeners().size());
+        assertEquals(listener, wdp.getWarningListeners().get(0));
+    }
+}

--- a/java_tests/org/opensha/sha/imr/attenRelImpl/test/CY_2008_test.java
+++ b/java_tests/org/opensha/sha/imr/attenRelImpl/test/CY_2008_test.java
@@ -18,18 +18,24 @@
 
 package org.opensha.sha.imr.attenRelImpl.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.StringTokenizer;
 
 import org.junit.Before;
+import org.junit.Test;
 import org.opensha.commons.exceptions.ConstraintException;
 import org.opensha.commons.exceptions.ParameterException;
 import org.opensha.commons.param.BooleanParameter;
 import org.opensha.commons.param.DoubleParameter;
+import org.opensha.commons.param.ParameterAPI;
 import org.opensha.commons.param.WarningDoubleParameter;
+import org.opensha.commons.param.event.ParameterChangeListener;
 import org.opensha.commons.util.DataUtils;
 import org.opensha.commons.util.FileUtils;
 import org.opensha.sha.imr.AttenuationRelationship;
@@ -538,4 +544,17 @@ public class CY_2008_test extends NGATest {
         return failMetadata;
     }
 
+    /**
+     * See https://bugs.launchpad.net/openquake/+bug/984838.
+     * 
+     * Tests that the SA Parameter's change listener is set properly.
+     */
+    @Test
+    public void testResetSaParamEventListener() {
+        cy_08.resetParameterEventListeners();
+        ParameterAPI param = cy_08.getParameter(SA_Param.NAME);
+        List<ParameterChangeListener> listeners = param.getChangeListeners();
+        assertEquals(1, listeners.size());
+        assertEquals(cy_08, listeners.get(0));
+    }
 }

--- a/java_tests/org/opensha/sha/imr/param/IntensityMeasureParams/SA_ParamTest.java
+++ b/java_tests/org/opensha/sha/imr/param/IntensityMeasureParams/SA_ParamTest.java
@@ -1,0 +1,64 @@
+package org.opensha.sha.imr.param.IntensityMeasureParams;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensha.commons.param.DoubleDiscreteConstraint;
+import org.opensha.commons.exceptions.WarningException;
+import org.opensha.commons.exceptions.ConstraintException;
+
+public class SA_ParamTest
+{
+
+    private SA_Param saParam;
+
+    @Before
+    public void setUp()
+    {
+        double[] period = { 0.01, 0.02, 0.03, 0.04, 0.05,
+                0.075, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4,
+                5, 7.5, 10};
+        DoubleDiscreteConstraint ddc = new DoubleDiscreteConstraint();
+        for (double d : period)
+        {
+            ddc.addDouble(d);
+        }
+
+        PeriodParam pp = new PeriodParam(ddc);
+        DampingParam dp = new DampingParam();
+
+        saParam = new SA_Param(pp, dp);
+    }
+
+    @Test
+    public void testDefaultWarnMax()
+    {
+        // Should succeed with no error.
+        // This is maximum allowed value.
+        saParam.setValue(Math.log(Double.MAX_VALUE));
+    }
+
+    @Test(expected=WarningException.class)
+    public void testDefaultWarnMax2()
+    {
+        saParam.setValue(Double.MAX_VALUE);
+    }
+
+    @Test(expected=WarningException.class)
+    public void testDefaultWarnMax3()
+    {
+        // The test value just slightly exceeds the max allowed value.
+        saParam.setValue(Math.log(Double.MAX_VALUE) + 0.0000000001);
+    }
+
+    @Test
+    public void testMinValue()
+    {
+        saParam.setValue(Math.log(Double.MIN_VALUE));
+    }
+
+    @Test(expected=ConstraintException.class)
+    public void testMinValue2()
+    {
+        saParam.setValue(Math.log(Double.MIN_VALUE) - 0.0000000001);
+    }
+}


### PR DESCRIPTION
Addresses: https://bugs.launchpad.net/openquake/+bug/984838

Solving this problem took 3 different modifications:
- WarningDoubleParameter.java: Add bullet-proofing the handling of the `warningListeners` list to ensure that we don't add `null` values. Otherwise, later on an event can be fired to a `null` `ParameterChangeWarningListener` , which obviously results in a `NullPointerException`.
- CY_2008_AttenRel.java: Next, the SA param was neglected in some of the parameter event listener handling. Fixing this prevents another `NullPointerException` in particular cases.
- SA_Param.java: Finally, I removed the restriction on the maximum values for spectral acceleration. Previously, the max value was set to `ln(3.0)` (or ~1.09). Having such a restriction causes this error:
  <pre>
  JavaException: Java traceback (most recent call last):
  File "UHSCalculator.java", line 153, in org.gem.calc.UHSCalculator.computeUHS
  File "UHSCalculator.java", line 244, in org.gem.calc.UHSCalculator.computeUHS
  File "UHSCalculator.java", line 402, in org.gem.calc.UHSCalculator.updateHazCurveForInterpolatedPeriod
  File "AttenuationRelationship.java", line 442, in org.opensha.sha.imr.AttenuationRelationship.setIntensityMeasureLevel
  File "WarningDoubleParameter.java", line 76, in org.opensha.commons.param.WarningDoubleParameter.setValue
  File "WarningDoubleParameter.java", line 539, in org.opensha.commons.param.WarningDoubleParameter.setValue
  org.opensha.commons.exceptions.WarningException: SA: setValue(): Value is not recommended: 1.2383742310432684
  </pre>
  After a discussion with Dr. Danciu and Dr. Monelli, it was concluded that this restriction was unnecessary.
